### PR TITLE
Fix typos

### DIFF
--- a/busser-minitest.gemspec
+++ b/busser-minitest.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "simplecov"
 
   # style and complexity libraries are tightly version pinned as newer releases
-  # may introduce new and undesireable style choices which would be immediately
+  # may introduce new and undesirable style choices which would be immediately
   # enforced in CI
   gem.add_development_dependency "chefstyle", "2.2.1"
 end


### PR DESCRIPTION
Fixes spelling mistakes found with the [`typos`](https://github.com/crate-ci/typos) linter.

Changes are limited to comments, documentation, and test descriptions -- no functional changes.

Files touched:
- busser-minitest.gemspec